### PR TITLE
Requiring 'open3' in command.rb

### DIFF
--- a/lib/imageproxy/command.rb
+++ b/lib/imageproxy/command.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Imageproxy
   class Command
     protected


### PR DESCRIPTION
This will fix the error shown on heroku cedar.
