### PR TITLE
added require "timeout"

### DIFF
--- a/lib/imageproxy/convert.rb
+++ b/lib/imageproxy/convert.rb
@@ -1,4 +1,5 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "command")
+require "timeout"
 
 module Imageproxy
   class Convert < Imageproxy::Command


### PR DESCRIPTION
I got errors when I was using puma.io without this require line.
